### PR TITLE
Deploy minified content to npm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,19 @@ cache:
 
 script:
   - npm run lint
+  - npm run build
+
+before_deploy:
+  - npm config set @zaproxy:registry https://registry.npmjs.org/
+  # `dist/front-end-track.js` appears in the `.gitignore`, so its won't be
+  # published, unless a `.npmignore` is present.
+  # c.f. https://docs.travis-ci.com/user/deployment/npm/#note-on-gitignore
+  - touch .npmignore
+
+deploy:
+  provider: npm
+  email: "${NPM_EMAIL}"
+  api_key: "${NPM_TOKEN}"
+  skip_cleanup: true
+  on:
+    tags: true

--- a/package.json
+++ b/package.json
@@ -34,6 +34,9 @@
   "dependencies": {
     "pubsub-js": "^1.6.0"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "xo": {
     "space": true,
     "globals": [


### PR DESCRIPTION
**/ ! \\ NOTE:** This requires the variables `NPM_EMAIL` and `NPM_TOKEN` ([NPM auth key](https://docs.travis-ci.com/user/deployment/npm/#npm-auth-token)) to be set in the settings for the repo on `travis-ci.com`.

Fixes #5:
  * publish minified version on npm
  * allowing its use from a CDN